### PR TITLE
Fix: Homepage class error issue in frontend preventing metadata image display

### DIFF
--- a/rair-front/src/components/MockUpPage/ImageLazy/ImageLazy.tsx
+++ b/rair-front/src/components/MockUpPage/ImageLazy/ImageLazy.tsx
@@ -20,6 +20,8 @@ export const ImageLazy: React.FC<IImageLazy> = ({
 
   const onLoad = (event) => {
     event.target.classList.add('loaded');
+
+    event.target.classList.add('has-error');
   };
 
   const onError = (event) => {


### PR DESCRIPTION
In this PR I've fixed an issue with className for image on HomePage