### PR TITLE
Read and Unread Filters

### DIFF
--- a/rair-node/bin/api/notifications/notifications.Controller.js
+++ b/rair-node/bin/api/notifications/notifications.Controller.js
@@ -7,7 +7,7 @@ const router = express.Router();
 router.get(
     '/',
     requireUserSession,
-    validation(['dbNotifications', 'pagination'], 'query'),
+    validation(['notificationsQuery', 'dbNotifications', 'pagination'], 'query'),
     listNotifications,
 );
 router.get(

--- a/rair-node/bin/api/notifications/notifications.Service.js
+++ b/rair-node/bin/api/notifications/notifications.Service.js
@@ -6,18 +6,24 @@ module.exports = {
     listNotifications: async (req, res, next) => {
         try {
             const {
-                read = false,
+                onlyRead,
+                onlyUnread,
                 type,
                 user, pageNum = 0,
                 itemsPerPage = 10,
             } = req.query;
             const { publicAddress, adminRights } = req.user;
             const filter = {
-                read,
                 user: publicAddress.toLowerCase(),
             };
             if (type) {
                 filter.type = type;
+            }
+            if (onlyRead) {
+                filter.read = true;
+            }
+            if (onlyUnread) {
+                filter.read = false;
             }
             if (user && adminRights) {
                 filter.user = user.toLowerCase();

--- a/rair-node/bin/schemas/index.js
+++ b/rair-node/bin/schemas/index.js
@@ -32,6 +32,7 @@ const importContract = require('./importContract');
 const { analyticsParams, analyticsQuery } = require('./analytics');
 const { tokenCreditQuery, tokenCreditWithdraw } = require('./credits');
 const { resaleQuery, resaleUpdate, resaleCreate } = require('./resales');
+const { notificationsQuery } = require('./notifications');
 // V2 validations
 const textSearch = require('./textSearch');
 const {
@@ -125,6 +126,9 @@ module.exports = {
   csvFileUpload,
   getTokenNumbers,
   tokenNumber,
+
+  // Notifications
+  notificationsQuery,
 
   // Common schemas
   pagination,

--- a/rair-node/bin/schemas/notifications.js
+++ b/rair-node/bin/schemas/notifications.js
@@ -1,0 +1,8 @@
+const Joi = require('joi');
+
+module.exports = {
+  notificationsQuery: () => ({
+    onlyRead: Joi.boolean(),
+    onlyUnread: Joi.boolean(),
+  }),
+};


### PR DESCRIPTION
Updates the api/notifications endpoint:
- read query param removed
- Added onlyRead and onlyUnread query params, will returns only read or unread notifications
- By default the endpoint will returns both types of notifications