### PR TITLE
156 - Transaction catcher with Alchemy/RPC switch

### DIFF
--- a/rair-sync/bin/integrations/ethers/transactionCatcher.js
+++ b/rair-sync/bin/integrations/ethers/transactionCatcher.js
@@ -34,7 +34,7 @@ const getTransaction = async (
     }).save();
 
     log.info(
-      `Querying hash ${transactionHash} on ${network} using Alchemy!`,
+      `Querying hash ${transactionHash} on ${network} using ${blockchainData.alchemySupport ? 'Alchemy' : 'RPC'}!`,
     );
 
     // Default values in case the Moralis SDK query works
@@ -45,16 +45,21 @@ const getTransaction = async (
     const transactionHashLabel = 'transactionHash';
 
     try {
+      let provider;
+      if (blockchainData.alchemySupport) {
+        provider = getAlchemy(blockchainData.hash).core;
+      } else if (blockchainData.rpcEndpoint) {
+        provider = ethers.getDefaultProvider(blockchainData.rpcEndpoint);
+      }
       // Catch any error if the SDK fails
-      const AlchemySDK = getAlchemy(network);
-      transactionReceipt = await AlchemySDK.core.getTransactionReceipt(transactionHash);
+      transactionReceipt = await provider.getTransactionReceipt(transactionHash);
     } catch (err) {
       log.error(err);
     }
 
     if (!transactionReceipt) {
       log.error(
-        `Validation failed for tx ${transactionHash}, couldn't get a response from Alchemy`,
+        `Validation failed for tx ${transactionHash}, couldn't get a response from provider`,
       );
       transactionReceipt = await getProvider(network)
         .getTransactionReceipt(transactionHash);

--- a/rair-sync/bin/tasks/sync.js
+++ b/rair-sync/bin/tasks/sync.js
@@ -15,7 +15,7 @@ module.exports = (context) => {
     { lockLifetime },
     async (task, done) => {
       try {
-        const chainsToProcess = Blockchain.find({}).lean();
+        const chainsToProcess = Blockchain.find({ sync: true }).lean();
         let startupTime = 0;
         // eslint-disable-next-line no-restricted-syntax
         for await (const chain of chainsToProcess) {

--- a/rair-sync/bin/utils/logUtils.js
+++ b/rair-sync/bin/utils/logUtils.js
@@ -111,7 +111,7 @@ const getTransactionHistory = async (address, blockchainData, fromBlock = 0) => 
       // console.error(Object.keys(error), error.reason);
       speedTier = 0;
     }
-  } while ((options.fromBlock + tiers[speedTier]) < latestBlock);
+  } while (options.toBlock !== undefined);
   log.info(`[${blockchainData.hash}] Found ${listOfTransaction.length} events on ${address}`);
   return listOfTransaction.map(processLog);
 };


### PR DESCRIPTION
Use the server settings to sync individual transactions with the provided RPC or with Alchemy's SDK

Closes #156 