### PR TITLE
152 - Prevent duplicate notifications

### DIFF
--- a/rair-sync/bin/utils/eventCatcherUtils/insertContract.js
+++ b/rair-sync/bin/utils/eventCatcherUtils/insertContract.js
@@ -25,9 +25,14 @@ module.exports = async (
     contractAddress: deploymentAddress.toLowerCase(),
     lastSyncedBlock: 0,
     external: false,
-  })
-    .save()
-    .catch(handleDuplicateKey);
+  });
+
+  try {
+    await contract.save();
+  } catch (error) {
+    handleDuplicateKey(error);
+    return [];
+  }
 
   redisPublisher.publish('notifications', JSON.stringify({
     type: 'message',

--- a/rair-sync/bin/utils/logUtils.js
+++ b/rair-sync/bin/utils/logUtils.js
@@ -9,7 +9,7 @@ const wasteTime = (ms) => new Promise((resolve) => {
   setTimeout(resolve, ms);
 });
 
-const tiers = [2000, 10000, 1000000, 2000000];
+const tiers = [2000, 10000, 100000, 1000000, 2000000];
 
 const processLog = (event) => {
   // Array of found events

--- a/rair-sync/bin/utils/reusableTransactionHandler.js
+++ b/rair-sync/bin/utils/reusableTransactionHandler.js
@@ -207,7 +207,7 @@ exports.syncEventsFromSingleContract = (taskName, contractName) => async (job, d
     // Otherwise it will keep increasing and could ignore events
     version.running = false;
     if (lastSuccessfullBlock.gt(version.number)) {
-      version.number = BigNumber.from(version.number).add(lastSuccessfullBlock).add(1).toString();
+      version.number = BigNumber.from(lastSuccessfullBlock).add(1).toString();
     }
     await version.save();
     log('Complete');


### PR DESCRIPTION
Update the syncing logic to prevent duplicate notifications if the task's latest block is reset to 0
Closes #152 