### PR TITLE
Fix style issue for serial number picker when there are more than a thousand tokens

### DIFF
--- a/rair-front/src/components/MockUpPage/SelectBox/SelectNumber/SelectNumber.tsx
+++ b/rair-front/src/components/MockUpPage/SelectBox/SelectNumber/SelectNumber.tsx
@@ -136,7 +136,8 @@ const SelectNumber: React.FC<ISelectNumber> = ({
           <div
             style={{
               background: primaryColor,
-              top: '0px'
+              top: '0',
+              alignContent: 'baseline'
             }}
             id="rred"
             className={'select-box--items list-of-tokens select-number-popup'}

--- a/rair-front/src/components/MockUpPage/SelectBox/SelectNumber/SelectNumber.tsx
+++ b/rair-front/src/components/MockUpPage/SelectBox/SelectNumber/SelectNumber.tsx
@@ -135,10 +135,11 @@ const SelectNumber: React.FC<ISelectNumber> = ({
           <div className="select-box--arrow"></div>
           <div
             style={{
-              background: primaryColor
+              background: primaryColor,
+              top: '0px'
             }}
             id="rred"
-            className={'select-box--items list-of-tokens'}
+            className={'select-box--items list-of-tokens select-number-popup'}
             ref={listOfTokensRef}>
             {ranges.map((range, index) => {
               return (


### PR DESCRIPTION
In this PR I've solved issue with style in Serial Number Picker
Before:
user cannot click to 5000+ ranges
After
User's able to click to any ranges tokens